### PR TITLE
Feature/dsc 103 simple mutations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,9 @@
       "version": "0.0.1",
       "license": "ISC",
       "dependencies": {
-        "ably": "^1.2.39",
+        "@types/lodash": "^4.14.195",
+        "ably": "^1.2.40",
+        "lodash": "^4.17.21",
         "rxjs": "^7.8.1"
       },
       "devDependencies": {
@@ -637,6 +639,11 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/lodash": {
+      "version": "4.14.195",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.195.tgz",
+      "integrity": "sha512-Hwx9EUgdwf2GLarOjQp5ZH8ZmblzcbTBC2wtQWNKARBSxM9ezRIAUpeDTgoQRAFB0+8CNWXVA9+MaSOzOF3nPg=="
+    },
     "node_modules/@types/node": {
       "version": "18.11.18",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.18.tgz",
@@ -1037,9 +1044,9 @@
       }
     },
     "node_modules/ably": {
-      "version": "1.2.39",
-      "resolved": "https://registry.npmjs.org/ably/-/ably-1.2.39.tgz",
-      "integrity": "sha512-xL57mIHGZsdJlgQv2DqZUFxgvh3QmUZOOZioP4dBbzCu6hgnoTlWHiZT40uwr0D8/OpAyvhidjhoVcqMk3TIAQ==",
+      "version": "1.2.40",
+      "resolved": "https://registry.npmjs.org/ably/-/ably-1.2.40.tgz",
+      "integrity": "sha512-Rmc/IBW9BQeDqaVZdeYD2HMakfzoumHw8Ag3JtqxdC8xcc50k69FDY3Y1t9Mp7nrDQDjDYXvHgiOkVp99jNjHA==",
       "dependencies": {
         "@ably/msgpack-js": "^0.4.0",
         "got": "^11.8.5",
@@ -2453,6 +2460,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -4086,6 +4098,11 @@
         "@types/node": "*"
       }
     },
+    "@types/lodash": {
+      "version": "4.14.195",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.195.tgz",
+      "integrity": "sha512-Hwx9EUgdwf2GLarOjQp5ZH8ZmblzcbTBC2wtQWNKARBSxM9ezRIAUpeDTgoQRAFB0+8CNWXVA9+MaSOzOF3nPg=="
+    },
     "@types/node": {
       "version": "18.11.18",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.18.tgz",
@@ -4354,9 +4371,9 @@
       }
     },
     "ably": {
-      "version": "1.2.39",
-      "resolved": "https://registry.npmjs.org/ably/-/ably-1.2.39.tgz",
-      "integrity": "sha512-xL57mIHGZsdJlgQv2DqZUFxgvh3QmUZOOZioP4dBbzCu6hgnoTlWHiZT40uwr0D8/OpAyvhidjhoVcqMk3TIAQ==",
+      "version": "1.2.40",
+      "resolved": "https://registry.npmjs.org/ably/-/ably-1.2.40.tgz",
+      "integrity": "sha512-Rmc/IBW9BQeDqaVZdeYD2HMakfzoumHw8Ag3JtqxdC8xcc50k69FDY3Y1t9Mp7nrDQDjDYXvHgiOkVp99jNjHA==",
       "requires": {
         "@ably/msgpack-js": "^0.4.0",
         "got": "^11.8.5",
@@ -5410,6 +5427,11 @@
       "requires": {
         "p-locate": "^5.0.0"
       }
+    },
+    "lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "lodash.merge": {
       "version": "4.6.2",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,9 @@
     "vitest": "^0.29.8"
   },
   "dependencies": {
-    "ably": "^1.2.39",
+    "@types/lodash": "^4.14.195",
+    "ably": "^1.2.40",
+    "lodash": "^4.17.21",
     "rxjs": "^7.8.1"
   }
 }

--- a/src/Model.test.ts
+++ b/src/Model.test.ts
@@ -3,8 +3,8 @@ import { Realtime, Types } from 'ably/promises';
 import { Subject, lastValueFrom } from 'rxjs';
 import { take } from 'rxjs/operators';
 
-import { createMessage } from './utilities/test/messages';
-import Model, { ModelState, Versioned, Streams } from './Model';
+import { createMessage, customMessage } from './utilities/test/messages';
+import Model, { ModelState, Versioned, Streams, Mutation } from './Model';
 import Stream from './Stream';
 
 vi.mock('ably/promises');
@@ -25,12 +25,32 @@ type TestData = {
   };
 };
 
+const simpleTestData: Versioned<TestData> = {
+  version: 1,
+  data: {
+    foo: 'foobar',
+    bar: {
+      baz: 1,
+    },
+  },
+};
+
 interface ModelTestContext {
   streams: Streams;
 }
 
 const modelStatePromise = <T>(model: Model<T>, state: ModelState) =>
   new Promise((resolve) => model.whenState(state, model.state, resolve));
+
+const getNthEventPromise = <T>(subject: Subject<T>, n: number) => lastValueFrom(subject.pipe(take(n)));
+
+const getEventPromises = <T>(subject: Subject<T>, n: number) => {
+  const promises: Promise<T>[] = [];
+  for (let i = 0; i < n; i++) {
+    promises.push(getNthEventPromise(subject, i + 1));
+  }
+  return promises;
+};
 
 describe('Model', () => {
   beforeEach<ModelTestContext>((context) => {
@@ -61,22 +81,12 @@ describe('Model', () => {
   });
 
   it<ModelTestContext>('enters ready state after sync and subscribed to streams', async ({ streams }) => {
-    const data: Versioned<TestData> = {
-      version: 1,
-      data: {
-        foo: 'foobar',
-        bar: {
-          baz: 1,
-        },
-      },
-    };
-
     // the promise returned by the subscribe method resolves when we have successfully attached to the channel
     let completeSync;
     const synchronised = new Promise((resolve) => (completeSync = resolve));
     const sync = vi.fn(async () => {
       await synchronised;
-      return data;
+      return simpleTestData;
     });
 
     streams.s1.subscribe = vi.fn();
@@ -92,7 +102,8 @@ describe('Model', () => {
     expect(streams.s1.subscribe).toHaveBeenCalledOnce();
     expect(streams.s2.subscribe).toHaveBeenCalledOnce();
     expect(sync).toHaveBeenCalledOnce();
-    expect(model.data).toEqual(data);
+    expect(model.optimistic).toEqual(simpleTestData.data);
+    expect(model.confirmed).toEqual(simpleTestData.data);
   });
 
   it<ModelTestContext>('pauses and resumes the model', async ({ streams }) => {
@@ -102,7 +113,7 @@ describe('Model', () => {
     streams.s2.pause = vi.fn();
     streams.s1.resume = vi.fn();
     streams.s2.resume = vi.fn();
-    const sync = vi.fn();
+    const sync = vi.fn(async () => simpleTestData);
 
     const model = new Model<TestData>('test', { streams, sync });
 
@@ -126,7 +137,7 @@ describe('Model', () => {
     streams.s2.subscribe = vi.fn();
     streams.s1.unsubscribe = vi.fn();
     streams.s2.unsubscribe = vi.fn();
-    const sync = vi.fn();
+    const sync = vi.fn(async () => simpleTestData);
 
     const model = new Model<TestData>('test', { streams, sync });
 
@@ -144,7 +155,7 @@ describe('Model', () => {
   it<ModelTestContext>('subscribes to updates', async ({ streams }) => {
     const data: Versioned<any> = {
       version: 0,
-      data: 'foobar',
+      data: 'data_0',
     };
 
     // event subjects used to invoke the stream subscription callbacks
@@ -163,20 +174,11 @@ describe('Model', () => {
     const sync = vi.fn(async () => data); // defines initial version of model
     const model = new Model<string>('test', { streams, sync });
 
-    const update1 = vi.fn(async (state, event) => ({
-      version: state.version + 1,
-      data: event.data,
-    }));
+    const update1 = vi.fn(async (state, event) => event.data);
     model.registerUpdate('s1', 'name_1', update1);
-    const update2 = vi.fn(async (state, event) => ({
-      version: state.version + 1,
-      data: event.data,
-    }));
+    const update2 = vi.fn(async (state, event) => event.data);
     model.registerUpdate('s2', 'name_2', update2);
-    const update3 = vi.fn(async (state, event) => ({
-      version: state.version + 1,
-      data: event.data,
-    }));
+    const update3 = vi.fn(async (state, event) => event.data);
     model.registerUpdate('s1', 'name_3', update3);
     model.registerUpdate('s2', 'name_3', update3);
 
@@ -184,13 +186,15 @@ describe('Model', () => {
     expect(sync).toHaveBeenCalledOnce();
 
     let subscription = new Subject<void>();
-    const subscriptionSpy = vi.fn<[Error | null | undefined, string | undefined]>(() => subscription.next());
+    const subscriptionSpy = vi.fn<[Error | null | undefined, string | undefined]>(() => {
+      subscription.next();
+    });
     model.subscribe(subscriptionSpy);
 
-    const subscriptionCalled = () => lastValueFrom(subscription.pipe(take(1)));
+    const subscriptionCalls = getEventPromises(subscription, 4);
 
     events.e1.next(createMessage(1));
-    await subscriptionCalled();
+    await subscriptionCalls[0];
     expect(update1).toHaveBeenCalledTimes(1);
     expect(update2).toHaveBeenCalledTimes(0);
     expect(update3).toHaveBeenCalledTimes(0);
@@ -198,7 +202,7 @@ describe('Model', () => {
     expect(subscriptionSpy).toHaveBeenNthCalledWith(1, null, 'data_1');
 
     events.e2.next(createMessage(2));
-    await subscriptionCalled();
+    await subscriptionCalls[1];
     expect(update1).toHaveBeenCalledTimes(1);
     expect(update2).toHaveBeenCalledTimes(1);
     expect(update3).toHaveBeenCalledTimes(0);
@@ -206,7 +210,7 @@ describe('Model', () => {
     expect(subscriptionSpy).toHaveBeenNthCalledWith(2, null, 'data_2');
 
     events.e1.next(createMessage(3));
-    await subscriptionCalled();
+    await subscriptionCalls[2];
     expect(update1).toHaveBeenCalledTimes(1);
     expect(update2).toHaveBeenCalledTimes(1);
     expect(update3).toHaveBeenCalledTimes(1);
@@ -214,17 +218,15 @@ describe('Model', () => {
     expect(subscriptionSpy).toHaveBeenNthCalledWith(3, null, 'data_3');
 
     events.e2.next(createMessage(3));
-    await subscriptionCalled();
+    await subscriptionCalls[3];
     expect(update1).toHaveBeenCalledTimes(1);
     expect(update2).toHaveBeenCalledTimes(1);
     expect(update3).toHaveBeenCalledTimes(2);
     expect(subscriptionSpy).toHaveBeenCalledTimes(4);
     expect(subscriptionSpy).toHaveBeenNthCalledWith(4, null, 'data_3');
 
-    expect(model.data).toEqual({
-      version: 4,
-      data: 'data_3',
-    });
+    expect(model.optimistic).toEqual('data_3');
+    expect(model.confirmed).toEqual('data_3');
   });
 
   it<ModelTestContext>('executes a registered mutation', async ({ streams }) => {
@@ -233,12 +235,14 @@ describe('Model', () => {
     const model = new Model<string>('test', { streams, sync: async () => ({ version: 1, data: 'foobar' }) });
     await modelStatePromise(model, ModelState.READY);
 
-    const mutation = vi.fn();
+    const mutation: Mutation = {
+      mutate: vi.fn(async () => ({ result: 'test', events: [] })),
+    };
     model.registerMutation('foo', mutation);
-    expect(mutation).toHaveBeenCalledTimes(0);
+    expect(mutation.mutate).toHaveBeenCalledTimes(0);
     await model.mutate<[string, number], void>('foo', 'bar', 123);
-    expect(mutation).toHaveBeenCalledTimes(1);
-    expect(mutation).toHaveBeenCalledWith('bar', 123);
+    expect(mutation.mutate).toHaveBeenCalledTimes(1);
+    expect(mutation.mutate).toHaveBeenCalledWith('bar', 123);
   });
 
   it<ModelTestContext>('fails to register a duplicate mutation', async ({ streams }) => {
@@ -247,13 +251,293 @@ describe('Model', () => {
     const model = new Model<string>('test', { streams, sync: async () => ({ version: 1, data: 'foobar' }) });
     await modelStatePromise(model, ModelState.READY);
 
-    const mutation = vi.fn();
+    const mutation: Mutation = { mutate: vi.fn() };
     model.registerMutation('foo', mutation);
-    expect(mutation).toHaveBeenCalledTimes(0);
+    expect(mutation.mutate).toHaveBeenCalledTimes(0);
     expect(() => model.registerMutation('foo', mutation)).toThrowError(
       `mutation with name 'foo' already registered on model 'test'`,
     );
   });
 
-  // TODO disposes of the model on stream failed
+  it<ModelTestContext>('fails to execute mutation with unregistered stream', async ({ streams }) => {
+    streams.s1.subscribe = vi.fn();
+    streams.s2.subscribe = vi.fn();
+    const model = new Model<string>('test', { streams, sync: async () => ({ version: 1, data: 'foobar' }) });
+    await modelStatePromise(model, ModelState.READY);
+
+    const mutation: Mutation = {
+      mutate: vi.fn(async () => ({ result: 'test', events: [{ stream: 'unknown', name: 'foo' }] })),
+    };
+    model.registerMutation('foo', mutation);
+    expect(mutation.mutate).toHaveBeenCalledTimes(0);
+    await expect(model.mutate('foo')).rejects.toThrow("stream with name 'unknown' not registered on model 'test'");
+  });
+
+  it<ModelTestContext>('updates model state with optimistic event', async ({ streams }) => {
+    streams.s1.subscribe = vi.fn();
+    streams.s2.subscribe = vi.fn();
+    const model = new Model<string>('test', { streams, sync: async () => ({ version: 1, data: 'data_0' }) });
+    await modelStatePromise(model, ModelState.READY);
+
+    const update1 = vi.fn(async (state, event) => event.data);
+    model.registerUpdate('s1', 'testEvent', update1);
+
+    const mutation: Mutation = {
+      mutate: vi.fn(async (stream: string) => ({
+        result: 'test',
+        events: [{ stream, name: 'testEvent', data: 'data_1' }],
+      })),
+    };
+    model.registerMutation('foo', mutation);
+
+    let optimisticSubscription = new Subject<void>();
+    const optimisticSubscriptionSpy = vi.fn<[Error | null | undefined, string | undefined]>(() =>
+      optimisticSubscription.next(),
+    );
+    model.subscribe(optimisticSubscriptionSpy);
+    const optimisticSubscriptionCall = getNthEventPromise(optimisticSubscription, 1);
+
+    let confirmedSubscription = new Subject<void>();
+    const confirmedSubscriptionSpy = vi.fn<[Error | null | undefined, string | undefined]>(() =>
+      confirmedSubscription.next(),
+    );
+    model.subscribe(confirmedSubscriptionSpy, { optimistic: false });
+
+    await model.mutate<[string], void>('foo', 's1');
+
+    await optimisticSubscriptionCall;
+    expect(model.optimistic).toEqual('data_1');
+    expect(model.confirmed).toEqual('data_0');
+    expect(optimisticSubscriptionSpy).toHaveBeenCalledOnce();
+    expect(optimisticSubscriptionSpy).toHaveBeenCalledWith(null, 'data_1');
+    expect(confirmedSubscriptionSpy).toHaveBeenCalledTimes(0);
+  });
+
+  it<ModelTestContext>('confirms an optimistic event', async ({ streams }) => {
+    streams.s1.subscribe = vi.fn();
+    streams.s2.subscribe = vi.fn();
+
+    const events = { e1: new Subject<Types.Message>() };
+    streams.s1.subscribe = vi.fn((callback) => {
+      events.e1.subscribe((message) => callback(null, message));
+    });
+
+    const model = new Model<string>('test', { streams, sync: async () => ({ version: 1, data: 'data_0' }) });
+    await modelStatePromise(model, ModelState.READY);
+
+    const update1 = vi.fn(async (state, event) => event.data);
+    model.registerUpdate('s1', 'testEvent', update1);
+
+    const mutation: Mutation = {
+      mutate: vi.fn(async (stream: string) => ({
+        result: 'test',
+        events: [{ stream, name: 'testEvent', data: 'data_1' }],
+      })),
+    };
+    model.registerMutation('foo', mutation);
+
+    let optimisticSubscription = new Subject<void>();
+    const optimisticSubscriptionSpy = vi.fn<[Error | null | undefined, string | undefined]>(() =>
+      optimisticSubscription.next(),
+    );
+    model.subscribe(optimisticSubscriptionSpy);
+    const optimisticSubscriptionCall = getNthEventPromise(optimisticSubscription, 1);
+
+    let confirmedSubscription = new Subject<void>();
+    const confirmedSubscriptionSpy = vi.fn<[Error | null | undefined, string | undefined]>(() =>
+      confirmedSubscription.next(),
+    );
+    model.subscribe(confirmedSubscriptionSpy, { optimistic: false });
+    const confirmedSubscriptionCall = getNthEventPromise(confirmedSubscription, 1);
+
+    await model.mutate<[string], void>('foo', 's1');
+
+    await optimisticSubscriptionCall;
+    expect(model.optimistic).toEqual('data_1');
+    expect(model.confirmed).toEqual('data_0');
+    expect(optimisticSubscriptionSpy).toHaveBeenCalledOnce();
+    expect(optimisticSubscriptionSpy).toHaveBeenCalledWith(null, 'data_1');
+    expect(confirmedSubscriptionSpy).toHaveBeenCalledTimes(0);
+
+    events.e1.next(customMessage('id_1', 'testEvent', 'data_1'));
+    await confirmedSubscriptionCall;
+    expect(confirmedSubscriptionSpy).toHaveBeenCalledOnce();
+    expect(confirmedSubscriptionSpy).toHaveBeenCalledWith(null, 'data_1');
+    expect(model.confirmed).toEqual('data_1');
+  });
+
+  it<ModelTestContext>('confirms optimistic events from multiple streams', async ({ streams }) => {
+    streams.s1.subscribe = vi.fn();
+    streams.s2.subscribe = vi.fn();
+
+    const events = {
+      e1: new Subject<Types.Message>(),
+      e2: new Subject<Types.Message>(),
+    };
+    streams.s1.subscribe = vi.fn((callback) => {
+      events.e1.subscribe((message) => callback(null, message));
+    });
+    streams.s2.subscribe = vi.fn((callback) => {
+      events.e2.subscribe((message) => callback(null, message));
+    });
+
+    const model = new Model<string>('test', { streams, sync: async () => ({ version: 1, data: '0' }) });
+    await modelStatePromise(model, ModelState.READY);
+
+    // Defines an update function which concatenates strings.
+    // This is a non-commutative operation which let's us inspect the order in
+    // in which updates are applied to the speculative vs confirmed states.
+    const update1 = vi.fn(async (state, event) => state + event.data);
+    model.registerUpdate('s1', 'testEvent', update1);
+    model.registerUpdate('s2', 'testEvent', update1);
+
+    const mutation: Mutation = {
+      mutate: vi.fn(async (stream: string, data: string) => ({
+        result: 'test',
+        events: [{ stream, name: 'testEvent', data }],
+      })),
+    };
+    model.registerMutation('foo', mutation);
+
+    let optimisticSubscription = new Subject<void>();
+    const optimisticSubscriptionSpy = vi.fn<[Error | null | undefined, string | undefined]>(() => {
+      optimisticSubscription.next();
+    });
+    model.subscribe(optimisticSubscriptionSpy);
+    const optimisticSubscriptionCall = getNthEventPromise(optimisticSubscription, 3);
+
+    let confirmedSubscription = new Subject<void>();
+    const confirmedSubscriptionSpy = vi.fn<[Error | null | undefined, string | undefined]>(() => {
+      confirmedSubscription.next();
+    });
+    model.subscribe(confirmedSubscriptionSpy, { optimistic: false });
+    const confirmedSubscriptionCalls = getEventPromises(confirmedSubscription, 3);
+
+    await model.mutate<[string, string], void>('foo', 's1', '1');
+    await model.mutate<[string, string], void>('foo', 's2', '2'); // will be last to be confirmed
+    await model.mutate<[string, string], void>('foo', 's1', '3');
+
+    // optimistic updates are applied in the order the mutations were called
+    await optimisticSubscriptionCall;
+    expect(model.optimistic).toEqual('0123');
+    expect(model.confirmed).toEqual('0');
+    expect(optimisticSubscriptionSpy).toHaveBeenCalledTimes(3);
+    expect(optimisticSubscriptionSpy).toHaveBeenNthCalledWith(1, null, '01');
+    expect(optimisticSubscriptionSpy).toHaveBeenNthCalledWith(2, null, '012');
+    expect(optimisticSubscriptionSpy).toHaveBeenNthCalledWith(3, null, '0123');
+    expect(confirmedSubscriptionSpy).toHaveBeenCalledTimes(0);
+
+    // Optimistic updates must be confirmed in-order only in the context of a single stream,
+    // so here we confirm s2 in a different order to the order the mutation were optimistically applied,
+    // and assert that the confirmed state is constructed in the correct order (which differs from the
+    // order in which the speculative state is constructed).
+
+    // confirm the first expected event
+    events.e1.next(customMessage('id_1', 'testEvent', '1'));
+    await confirmedSubscriptionCalls[0];
+    expect(model.optimistic).toEqual('0123');
+    expect(model.confirmed).toEqual('01');
+    expect(confirmedSubscriptionSpy).toHaveBeenCalledTimes(1);
+    expect(confirmedSubscriptionSpy).toHaveBeenNthCalledWith(1, null, '01');
+    expect(optimisticSubscriptionSpy).toHaveBeenCalledTimes(3); // unchanged
+
+    // confirm the third expected event (second event on the first stream)
+    events.e1.next(customMessage('id_2', 'testEvent', '3'));
+    await confirmedSubscriptionCalls[1];
+    expect(model.optimistic).toEqual('0123');
+    expect(model.confirmed).toEqual('013');
+    expect(confirmedSubscriptionSpy).toHaveBeenCalledTimes(2);
+    expect(confirmedSubscriptionSpy).toHaveBeenNthCalledWith(2, null, '013');
+    expect(optimisticSubscriptionSpy).toHaveBeenCalledTimes(3); // unchanged
+
+    // confirm the second expected event (first event on the second stream)
+    events.e2.next(customMessage('id_1', 'testEvent', '2'));
+    await confirmedSubscriptionCalls[2];
+    expect(model.optimistic).toEqual('0123');
+    expect(model.confirmed).toEqual('0132');
+    expect(confirmedSubscriptionSpy).toHaveBeenCalledTimes(3);
+    expect(confirmedSubscriptionSpy).toHaveBeenNthCalledWith(3, null, '0132');
+    expect(optimisticSubscriptionSpy).toHaveBeenCalledTimes(3); // unchanged
+  });
+
+  it<ModelTestContext>('rebases optimistic events on top of confirmed state', async ({ streams }) => {
+    streams.s1.subscribe = vi.fn();
+    streams.s2.subscribe = vi.fn();
+
+    const events = { e1: new Subject<Types.Message>() };
+    streams.s1.subscribe = vi.fn((callback) => {
+      events.e1.subscribe((message) => callback(null, message));
+    });
+
+    const model = new Model<string>('test', { streams, sync: async () => ({ version: 1, data: '0' }) });
+    await modelStatePromise(model, ModelState.READY);
+
+    const update1 = vi.fn(async (state, event) => state + event.data);
+    model.registerUpdate('s1', 'testEvent', update1);
+
+    const mutation: Mutation = {
+      mutate: vi.fn(async (stream: string, data: string) => ({
+        result: 'test',
+        events: [{ stream, name: 'testEvent', data }],
+      })),
+    };
+    model.registerMutation('foo', mutation);
+
+    let optimisticSubscription = new Subject<void>();
+    const optimisticSubscriptionSpy = vi.fn<[Error | null | undefined, string | undefined]>(() => {
+      optimisticSubscription.next();
+    });
+    model.subscribe(optimisticSubscriptionSpy);
+    const optimisticSubscriptionCall = getEventPromises(optimisticSubscription, 3);
+
+    let confirmedSubscription = new Subject<void>();
+    const confirmedSubscriptionSpy = vi.fn<[Error | null | undefined, string | undefined]>(() => {
+      confirmedSubscription.next();
+    });
+    model.subscribe(confirmedSubscriptionSpy, { optimistic: false });
+    const confirmedSubscriptionCalls = getEventPromises(confirmedSubscription, 3);
+
+    await model.mutate<[string, string], void>('foo', 's1', '1');
+    await model.mutate<[string, string], void>('foo', 's1', '2');
+
+    // optimistic updates are applied in the order the mutations were called
+    await optimisticSubscriptionCall[0];
+    await optimisticSubscriptionCall[1];
+    expect(model.optimistic).toEqual('012');
+    expect(model.confirmed).toEqual('0');
+    expect(optimisticSubscriptionSpy).toHaveBeenCalledTimes(2);
+    expect(optimisticSubscriptionSpy).toHaveBeenNthCalledWith(1, null, '01');
+    expect(optimisticSubscriptionSpy).toHaveBeenNthCalledWith(2, null, '012');
+    expect(confirmedSubscriptionSpy).toHaveBeenCalledTimes(0);
+
+    // confirm the first expected event
+    events.e1.next(customMessage('id_1', 'testEvent', '1'));
+    await confirmedSubscriptionCalls[0];
+    expect(model.optimistic).toEqual('012');
+    expect(model.confirmed).toEqual('01');
+    expect(confirmedSubscriptionSpy).toHaveBeenCalledTimes(1);
+    expect(confirmedSubscriptionSpy).toHaveBeenNthCalledWith(1, null, '01');
+    expect(optimisticSubscriptionSpy).toHaveBeenCalledTimes(2);
+
+    // an event is received which does not have a corresponding expected event,
+    // and the speculative updates are rebased on top of the incoming event
+    events.e1.next(customMessage('id_1', 'testEvent', '3'));
+    await confirmedSubscriptionCalls[1];
+    await optimisticSubscriptionCall[2];
+    expect(model.optimistic).toEqual('0132');
+    expect(model.confirmed).toEqual('013');
+    expect(confirmedSubscriptionSpy).toHaveBeenCalledTimes(2);
+    expect(confirmedSubscriptionSpy).toHaveBeenNthCalledWith(2, null, '013');
+    expect(optimisticSubscriptionSpy).toHaveBeenCalledTimes(3);
+    expect(optimisticSubscriptionSpy).toHaveBeenNthCalledWith(3, null, '0132');
+
+    // confirm the second expected event
+    events.e1.next(customMessage('id_1', 'testEvent', '2'));
+    await confirmedSubscriptionCalls[2];
+    expect(model.optimistic).toEqual('0132');
+    expect(model.confirmed).toEqual('0132');
+    expect(confirmedSubscriptionSpy).toHaveBeenCalledTimes(3);
+    expect(confirmedSubscriptionSpy).toHaveBeenNthCalledWith(3, null, '0132');
+    expect(optimisticSubscriptionSpy).toHaveBeenCalledTimes(3);
+  });
 });

--- a/src/utilities/test/messages.ts
+++ b/src/utilities/test/messages.ts
@@ -41,3 +41,7 @@ export function createMessage(i: number): Types.Message {
     data: `data_${i}`,
   };
 }
+
+export function customMessage(id: string, name: string, data: string): Types.Message {
+  return { ...baseMessage, id, name, data };
+}


### PR DESCRIPTION
Adds functionality to register mutation functions on a model and execute them.

A mutation function includes a `mutate` method which is intended to perform the actual mutation to the data in the backend via e.g. a REST API call. The backend endpoint is expected to emit an event which the model will ultimately consume to update its local state via an update function.

The mutation function additionally returns the set of expected events that the model anticipates it will eventually receive to confirm the mutation. These events are optimistically applied locally to construct an optimistic model state. As confirmed events arrive, optimistic events are either then confirmed or rebased on top of the latest confirmed state.

The subscription callback is amended to support subscribing to either the latest speculative, optimistic state (`optimistic = true`) or only the confirmed state otherwise.

This PR does not include:

- Detecting optimistic events that are never confirmed
- Custom event matchers (confirmed events are matched against optimistic events via an equality check on the `name`, `stream` and `data` fields, which may be limiting)
- Handling conflicts via errors thrown in update functions
- Resyncing

A subsequent PR will address these issues.