### PR TITLE
model: avoid modifying array while iterating

### DIFF
--- a/src/Model.ts
+++ b/src/Model.ts
@@ -354,12 +354,7 @@ class Model<T> extends EventEmitter<Record<ModelState, ModelStateChange>> {
     // Remove any events from optimisticEvents and re-apply any unconfirmed
     // optimistic events.
     for (let event of events) {
-      for (let i = 0; i < this.optimisticEvents.length; i++) {
-        let e = this.optimisticEvents[i];
-        if (eventsAreEqual(e, event)) {
-          this.optimisticEvents.splice(i, 1);
-        }
-      }
+      this.optimisticEvents = this.optimisticEvents.filter((e) => !eventsAreEqual(e, event));
     }
     let nextData = this.confirmedData;
     for (const e of this.optimisticEvents) {


### PR DESCRIPTION
Modifying array while iterating can miss an element

The other `splice` is fine as it immediately `break`s