### PR TITLE
updatesregistry: event confirmed in update fn

### DIFF
--- a/src/Model.ts
+++ b/src/Model.ts
@@ -355,7 +355,7 @@ class Model<T, M extends MutationMethods> extends EventEmitter<Record<ModelState
     }, 0);
   }
 
-  private async applyUpdates(initialData: T, event: Event): Promise<T> {
+  private async applyUpdates(initialData: T, event: OptimisticEvent | ConfirmedEvent): Promise<T> {
     this.logger.trace({ ...this.baseLogContext, action: 'applyUpdates()', initialData, event });
     let data = initialData;
     const updates = this.updatesRegistry.get({ channel: event.channel, event: event.name });

--- a/src/UpdatesRegistry.ts
+++ b/src/UpdatesRegistry.ts
@@ -1,7 +1,7 @@
-import type { Event } from './Model.js';
+import type { ConfirmedEvent, OptimisticEvent } from './Model.js';
 import { UpdateRegistrationError } from './Errors.js';
 
-export type UpdateFunc<T> = (state: T, event: Event) => Promise<T>;
+export type UpdateFunc<T> = (state: T, event: OptimisticEvent | ConfirmedEvent) => Promise<T>;
 
 export type UpdateFuncs<T> = {
   [channel: string]: {


### PR DESCRIPTION
It is useful to know whether an incoming event is optimistic or confirmed in an update function so that the resultant state can be decorated with properties to render a different view in each case.