### PR TITLE
mutations: fix return type of mutation handler

### DIFF
--- a/src/MutationsRegistry.ts
+++ b/src/MutationsRegistry.ts
@@ -106,7 +106,7 @@ export default class MutationsRegistry<M extends MutationMethods> {
           Promise.resolve(),
         ];
         if (events && events.length > 0) {
-          callbackResult = await this.callbacks.onEvents(events); // TODO this doesn't need awaiting, but tests fail if not awaited
+          callbackResult = await this.callbacks.onEvents(events);
         }
         return expectedEvents ? [result, ...callbackResult] : result;
       } catch (err) {

--- a/src/types/mutations.ts
+++ b/src/types/mutations.ts
@@ -57,6 +57,6 @@ export type MethodWithExpect<M extends MutationMethods> = {
     $expect: (
       expectedEvents: Event[],
       comparator?: EventComparator,
-    ) => (...args: Parameters<M[K]>) => Awaited<[ReturnType<M[K]>, Promise<void>, Promise<void>]>;
+    ) => (...args: Parameters<M[K]>) => Promise<[Awaited<ReturnType<M[K]>>, Promise<void>, Promise<void>]>;
   };
 };


### PR DESCRIPTION
The mutation handler returns a promise, which the type definition did not reflect. Additionally, it awaits the mutation func itself.