### PR TITLE
ModelsClient implicitly calls sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,15 +167,12 @@ async function updatePost(mutationID: string, content: string) {
 }
 
 // create a new model instance called 'post' by passing the sync and merge functions
-const model = modelsClient.models.get<Post>({
+const model = await modelsClient.models.get<Post>({
   name: 'post',
   channelName: 'models:posts',
   sync: sync,
   merge: merge,
 })
-
-// run the initial sync
-await model.$sync()
 
 // subscribe to live changes to the model data!
 model.subscribe((err, post) => {
@@ -189,7 +186,7 @@ model.subscribe((err, post) => {
 // apply an optimistic update to the model
 // confirmation is a promise that resolves when the optimistic update is confirmed by the backend.
 // cancel is a function that can be used to cancel and rollback the optimistic update.
-const [confirmation, cancel] = await model1.optimistic({
+const [confirmation, cancel] = await model.optimistic({
     mutationID: 'my-mutation-id',
     name: 'updatePost',
     data: 'new post text',

--- a/docs/concepts/usage.md
+++ b/docs/concepts/usage.md
@@ -29,15 +29,12 @@ Note that we pass in the shape of our data model (`Post`) as a type parameter.
 In order to instantiate the model, we need to pass some *registrations* which link up the model to your application code.
 
 ```ts
-const model = modelsClient.models.get<Post>({
+const model = await modelsClient.models.get<Post>({
   name: /* ... */,
   channelName: /* ... */,
   sync: /* ... */,
   merge: /* ... */,
 })
-
-// run the initial sync
-await model.$sync()
 ```
 
 ## Sync Function
@@ -58,12 +55,10 @@ async function sync() {
   return result.json();
 }
 
-const model = modelsClient.models.get<Post>({
+const model = await modelsClient.models.get<Post>({
   sync: /* ... */,
   /* other registrations */
 })
-
-await model.$sync()
 ```
 
 The model will invoke this function at the start of its lifecycle to initialise your model state. Additionally, this function will be invoked if the model needs to re-synchronise at any point, for example after an extended period of network disconnectivity.

--- a/examples/posts/lib/models/hook.ts
+++ b/examples/posts/lib/models/hook.ts
@@ -29,13 +29,12 @@ export const useModel = (id: number) => {
     const ably = assertConfiguration();
     const modelsClient = new ModelsClient({ ably, optimisticEventOptions: { timeout: 5000 } });
     const init = async () => {
-      const model = modelsClient.models.get<PostType>({
+      const model = await modelsClient.models.get<PostType>({
         name: `post:${id}`,
         channelName: `post:${id}`,
         sync: async () => getPost(id),
         merge: merge,
       });
-      await model.sync();
 
       setModel(model);
     };

--- a/examples/simple/index.ts
+++ b/examples/simple/index.ts
@@ -68,9 +68,8 @@ const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
     }
   }
 
-  const model = modelsClient.models.get<Post>({name: 'post', channelName: channelName, sync: sync, merge: merge});
-  logger.info('sync: starting the model');
-  await model.sync();
+  const model = await modelsClient.models.get<Post>({name: 'post', channelName: channelName, sync: sync, merge: merge});
+  logger.info('started the model');
 
   model.on((event) => logger.info({event}, 'model state update'));
 

--- a/src/ModelsClient.ts
+++ b/src/ModelsClient.ts
@@ -55,9 +55,8 @@ export default class ModelsClient {
        * Gets an existing or creates a new model instance with the given name.
        * @param {ModelSpec} spec - The name, channelName, sync and merge functions for this model.
        * The names and funcitons will be automatically setup on the model returned.
-       * The model will not start until you call model.sync()
        */
-      get: <T>(spec: ModelSpec<T>) => {
+      get: async <T>(spec: ModelSpec<T>) => {
         const name = spec.name;
         const channelName = spec.channelName;
 
@@ -71,6 +70,9 @@ export default class ModelsClient {
 
         const model = new Model<T>(name, spec, { ...this.opts, channelName });
         this.modelInstances[name] = model;
+
+        await model.sync();
+
         return model as Model<T>;
       },
     };


### PR DESCRIPTION
Update modelsClient.models.get<T>(...) to call sync. This fixes a common source of bugs where programmers could easily forget to call sync on the model after it had been returned.