### PR TITLE
Recover from failed channel state

### DIFF
--- a/src/stream/Stream.ts
+++ b/src/stream/Stream.ts
@@ -148,7 +148,10 @@ export default class Stream extends EventEmitter<Record<StreamState, StreamState
     this.middleware.subscribe(this.onMiddlewareMessage.bind(this));
 
     this.ablyChannel = this.ably.channels.get(this.options.channelName);
-    this.ablyChannel.on('failed', (change) => this.dispose(change.reason));
+    this.ablyChannel.on('failed', (change) => {
+      this.dispose(change.reason);
+      this.subscriptions.error(new Error('Stream failed: ' + change.reason));
+    });
     this.ablyChannel.on(['suspended', 'update'], () => {
       this.subscriptions.error(new Error('discontinuity in channel connection'));
     });


### PR DESCRIPTION
Resync when the channel enters the failed state.
If the first resync fails, the SDK will continue to attempt to reconnect every 15 seconds.