### PR TITLE
client: add agent channel param and client option

### DIFF
--- a/src/ModelsClient.test.ts
+++ b/src/ModelsClient.test.ts
@@ -2,6 +2,7 @@ import { Realtime, Types } from 'ably/promises';
 import { vi, it, describe, expect, expectTypeOf, beforeEach } from 'vitest';
 
 import ModelsClient from './ModelsClient.js';
+import { VERSION } from './version.js';
 
 interface ModelsTestContext {
   ably: Types.RealtimePromise;
@@ -23,9 +24,17 @@ describe('ModelsClient', () => {
     context.ably.connection.whenState = vi.fn<any, any>();
   });
 
-  it<ModelsTestContext>('expects the injected client to be of the type RealtimePromise', ({ ably }) => {
+  it<ModelsTestContext>('correctly instantiates the models client', ({ ably }) => {
     const modelsClient = new ModelsClient({ ably });
     expectTypeOf(modelsClient.ably).toMatchTypeOf<Types.RealtimePromise>();
+    expect(modelsClient.ably['options']).toEqual({ agents: { models: VERSION } });
+  });
+
+  it<ModelsTestContext>('preserves existing agent', ({ ably }) => {
+    ably['options'] = { agents: { foo: 'bar' } };
+    const modelsClient = new ModelsClient({ ably });
+    expectTypeOf(modelsClient.ably).toMatchTypeOf<Types.RealtimePromise>();
+    expect(modelsClient.ably['options']).toEqual({ agents: { models: VERSION, foo: 'bar' } });
   });
 
   it<ModelsTestContext>('getting a model with the same name returns the same instance', async ({

--- a/src/ModelsClient.ts
+++ b/src/ModelsClient.ts
@@ -1,3 +1,4 @@
+import { Types as AblyTypes } from 'ably';
 import pino from 'pino';
 
 import Model from './Model.js';
@@ -5,6 +6,13 @@ import { defaultEventBufferOptions, defaultOptimisticEventOptions, defaultSyncOp
 import type { ModelsOptions, ModelOptions, ModelSpec, SyncFuncConstraint } from './types/model.js';
 import type { OptimisticEventOptions, SyncOptions } from './types/optimistic.js';
 import type { EventBufferOptions } from './types/stream.js';
+import { VERSION } from './version.js';
+
+interface AblyClientWithOptions extends AblyTypes.RealtimePromise {
+  options?: {
+    agents?: Record<string, string | boolean>;
+  };
+}
 
 /**
  * ModelsClient captures the set of named Model instances used by your application.
@@ -13,8 +21,6 @@ import type { EventBufferOptions } from './types/stream.js';
 export default class ModelsClient {
   private opts: Omit<ModelOptions, 'channelName'>;
   private modelInstances: Record<string, Model<any>> = {};
-
-  readonly version = '0.0.2';
 
   /**
    * @param {ModelsOptions} options - Options used to configure all models instantiated here, including the underlying Ably client.
@@ -39,7 +45,16 @@ export default class ModelsClient {
       optimisticEventOptions,
       eventBufferOptions,
     };
+    this.addAgent(this.opts.ably as AblyClientWithOptions);
     this.options.ably.time();
+  }
+
+  private addAgent(client: AblyClientWithOptions) {
+    const agent = { models: VERSION };
+    if (!client['options']) {
+      client['options'] = {};
+    }
+    client['options'].agents = { ...client['options'].agents, ...agent };
   }
 
   /**

--- a/src/stream/Stream.test.ts
+++ b/src/stream/Stream.test.ts
@@ -8,6 +8,7 @@ import { defaultSyncOptions, defaultEventBufferOptions } from '../Options.js';
 import type { StreamOptions } from '../types/stream.js';
 import { statePromise } from '../utilities/promises.js';
 import { createMessage } from '../utilities/test/messages.js';
+import { VERSION } from '../version.js';
 
 vi.mock('ably/promises');
 
@@ -74,6 +75,13 @@ describe('Stream', () => {
     await expect(replayPromise).resolves.toBeUndefined();
     expect(stream.state).toBe('ready');
 
+    expect(ably.channels.get).toHaveBeenCalledTimes(2);
+    expect(ably.channels.get).toHaveBeenNthCalledWith(1, channelName); // initial call from test
+    expect(ably.channels.get).toHaveBeenNthCalledWith(2, channelName, {
+      params: {
+        agent: `models/${VERSION}`,
+      },
+    }); // internal call with agent channel param
     expect(channel.subscribe).toHaveBeenCalledOnce();
     expect(channel.history).toHaveBeenCalledOnce();
     expect(channel.history).toHaveBeenNthCalledWith(1, {

--- a/src/stream/Stream.ts
+++ b/src/stream/Stream.ts
@@ -6,6 +6,7 @@ import { OrderedHistoryResumer } from './Middleware.js';
 import type { StandardCallback } from '../types/callbacks';
 import type { StreamStateChange, StreamOptions, StreamState } from '../types/stream.js';
 import EventEmitter from '../utilities/EventEmitter.js';
+import { VERSION } from '../version.js';
 
 export interface IStream {
   get state(): StreamState;
@@ -147,7 +148,7 @@ export default class Stream extends EventEmitter<Record<StreamState, StreamState
     );
     this.middleware.subscribe(this.onMiddlewareMessage.bind(this));
 
-    this.ablyChannel = this.ably.channels.get(this.options.channelName);
+    this.ablyChannel = this.ably.channels.get(this.options.channelName, { params: { agent: `models/${VERSION}` } });
     this.ablyChannel.on('failed', (change) => {
       this.dispose(change.reason);
       this.subscriptions.error(new Error('Stream failed: ' + change.reason));

--- a/src/version.test.ts
+++ b/src/version.test.ts
@@ -1,0 +1,10 @@
+import { describe, it, expect } from 'vitest';
+
+import { VERSION } from './version.js';
+import packageJson from '../package.json';
+
+describe('VERSION', () => {
+  it('runtime version matches package.json entry', () => {
+    expect(packageJson.version).toEqual(VERSION);
+  });
+});

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,0 +1,3 @@
+// Manually update when bumping version
+const VERSION = '0.0.2';
+export { VERSION };


### PR DESCRIPTION
Adds an "agent" channel param with value "models/<version>" to facilitate usage tracking. Additionally sets the agent option in the Ably client.

See: https://ably.atlassian.net/wiki/spaces/ENG/pages/2728362052/ADR101+Tracking+wrapper+SDK+usage

Cf. with Spaces usage tracking: 
- https://github.com/ably/spaces/blob/946b49c3048d2e1325afc2e6f21bedf7a4f07ac1/src/Space.ts#L149
- https://github.com/ably/spaces/blob/main/src/Spaces.ts#L64-L67

Also requires an update to ably-common, see: https://github.com/ably/ably-common/pull/224