### PR TITLE
fix: Add the correct api dos link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ For more information, see [usage docs](./docs/usage.md).
  For more information, see:
 
 * Read the [docs](/docs/)
-* Browse the [API docs](/docs/typedoc/generated/index.html)
+* Browse the [API docs](https://sdk.ably.com/builds/ably-labs/models/main/typedoc/)
 * Explore the [examples](/examples)
 
 ## Feedback


### PR DESCRIPTION
The current link is broken and points to a local directory. This PR updates the readme with the correct link.