### PR TITLE
DTP-711: Handle SequenceId edge cases

### DIFF
--- a/src/Model.test.ts
+++ b/src/Model.test.ts
@@ -1646,7 +1646,7 @@ describe('Model', () => {
         eventBufferOptions: defaultEventBufferOptions,
       },
     );
-    model.sync();
+    await model.sync();
     expect(syncFn).toHaveReturnedTimes(1);
 
     const lis: EventListener<ModelStateChange> = vi.fn<any, any>();

--- a/src/Model.test.ts
+++ b/src/Model.test.ts
@@ -150,7 +150,7 @@ describe('Model', () => {
     );
     model.on('errored', erroredListener);
 
-    await model.sync().catch((err) => expect(err.message).toEqual('sync function response: sequenceId is undefined'));
+    await model.sync().catch((err) => expect(err.message).toEqual('The sync function returned an undefined sequenceId'));
     expect(sync).toHaveBeenCalledOnce(); // sync is not retried
     expect(merge).not.toHaveBeenCalled();
     expect(erroredListener).toHaveBeenCalledOnce();
@@ -179,7 +179,7 @@ describe('Model', () => {
     );
     model.on('errored', erroredListener);
 
-    await model.sync().catch((err) => expect(err.message).toEqual('sync function response: sequenceId is undefined'));
+    await model.sync().catch((err) => expect(err.message).toEqual('The sync function returned an undefined sequenceId'));
     expect(sync).toHaveBeenCalledOnce();
     expect(merge).not.toHaveBeenCalled();
     expect(erroredListener).toHaveBeenCalledOnce();

--- a/src/Model.test.ts
+++ b/src/Model.test.ts
@@ -150,7 +150,9 @@ describe('Model', () => {
     );
     model.on('errored', erroredListener);
 
-    await model.sync().catch((err) => expect(err.message).toEqual('The sync function returned an undefined sequenceId'));
+    await model
+      .sync()
+      .catch((err) => expect(err.message).toEqual('The sync function returned an undefined sequenceId'));
     expect(sync).toHaveBeenCalledOnce(); // sync is not retried
     expect(merge).not.toHaveBeenCalled();
     expect(erroredListener).toHaveBeenCalledOnce();
@@ -179,7 +181,9 @@ describe('Model', () => {
     );
     model.on('errored', erroredListener);
 
-    await model.sync().catch((err) => expect(err.message).toEqual('The sync function returned an undefined sequenceId'));
+    await model
+      .sync()
+      .catch((err) => expect(err.message).toEqual('The sync function returned an undefined sequenceId'));
     expect(sync).toHaveBeenCalledOnce();
     expect(merge).not.toHaveBeenCalled();
     expect(erroredListener).toHaveBeenCalledOnce();

--- a/src/Model.test.ts
+++ b/src/Model.test.ts
@@ -180,7 +180,7 @@ describe('Model', () => {
     model.on('errored', erroredListener);
 
     await model.sync().catch((err) => expect(err.message).toEqual('sync function response: sequenceId is undefined'));
-    expect(sync).toHaveBeenCalledOnce(); // sync is not retried
+    expect(sync).toHaveBeenCalledOnce();
     expect(merge).not.toHaveBeenCalled();
     expect(erroredListener).toHaveBeenCalledOnce();
   });

--- a/src/Model.test.ts
+++ b/src/Model.test.ts
@@ -131,7 +131,7 @@ describe('Model', () => {
     ably,
     logger,
   }) => {
-    const retryConfig = 5;
+    const configNumRetries = 5;
     const sync = vi.fn(async () => ({ data: simpleTestData, sequenceId: undefined }));
     const merge = vi.fn();
     const erroredListener = vi.fn();
@@ -143,7 +143,7 @@ describe('Model', () => {
         ably,
         channelName,
         logger,
-        syncOptions: { ...defaultSyncOptions, retryStrategy: fixedRetryStrategy(10, retryConfig) },
+        syncOptions: { ...defaultSyncOptions, retryStrategy: fixedRetryStrategy(10, configNumRetries) },
         optimisticEventOptions: defaultOptimisticEventOptions,
         eventBufferOptions: defaultEventBufferOptions,
       },

--- a/src/Model.test.ts
+++ b/src/Model.test.ts
@@ -1550,7 +1550,6 @@ describe('Model', () => {
     streams,
   }) => {
     const s1 = streams.newStream({ channelName: channelName });
-    s1.subscribe = vi.fn();
 
     const events = new Subject<Types.Message>();
     s1.subscribe = vi.fn(async (callback) => {

--- a/src/stream/Stream.ts
+++ b/src/stream/Stream.ts
@@ -197,6 +197,14 @@ export default class Stream extends EventEmitter<Record<StreamState, StreamState
       n++;
     } while (page && page.items && page.items.length > 0 && page.hasNext() && !done);
 
+    if (sequenceId === '0' && this.middleware.state !== 'success') {
+      // The sequenceId is 0 there will be no message in the history to match it.
+      // The middleware is not in success which means there is some history so we apply it
+      // The situation occurs when history has been added in the time between the sync function resolving the stream
+      // getting to this point
+      this.middleware.applyHistory();
+    }
+
     // If the middleware is not in the success state it means there were some history messages and we never reached the target sequenceId.
     // This means the target sequenceId was too old and a re-sync from a newer state snapshot is required.
     if (this.middleware.state !== 'success') {


### PR DESCRIPTION
This PRs adds tests and validation handling for the sequenceId return from the configured sync function.

Conditions:
- [x] 1. SequenceId is `undefined`
- [x] 2. SequenceId is `'0'` and there is history in the channel. In which case history should be applied.


# comments

In scenario 1 where the sequenceId is `undefined`, the solution in this PR is throw an error and set the model state to `errored`. Additionally the `retryable()` logic has been updated to not run the callback function if the model is in the `errored`. Additionally if we catch an error while in the errored state then we re throw it, propagating it up the call stack. This is how the new `sequenceId is undefined error` will be surfaced to the user. 
