### PR TITLE
DTP-711: Handle SequenceId edge cases

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "typedoc-plugin-missing-exports": "^2.1.0"
       },
       "devDependencies": {
+        "@types/uuid": "^9.0.8",
         "@typescript-eslint/eslint-plugin": "^6.1.0",
         "@typescript-eslint/parser": "^6.1.0",
         "@vitest/coverage-c8": "^0.33.0",
@@ -892,6 +893,12 @@
       "version": "7.5.6",
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.6.tgz",
       "integrity": "sha512-dn1l8LaMea/IjDoHNd9J52uBbInB796CDffS6VdIxvqYCPSG0V0DzHp76GpaWnlhg88uYyPbXCDIowa86ybd5A==",
+      "dev": true
+    },
+    "node_modules/@types/uuid": {
+      "version": "9.0.8",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
+      "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==",
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -5799,6 +5806,12 @@
       "version": "7.5.6",
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.6.tgz",
       "integrity": "sha512-dn1l8LaMea/IjDoHNd9J52uBbInB796CDffS6VdIxvqYCPSG0V0DzHp76GpaWnlhg88uYyPbXCDIowa86ybd5A==",
+      "dev": true
+    },
+    "@types/uuid": {
+      "version": "9.0.8",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
+      "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==",
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "prettier": "^3.1.0",
         "typedoc": "^0.25.3",
         "typescript": "^5.1.6",
+        "uuid": "^9.0.1",
         "vitest": "^0.34.1"
       }
     },
@@ -4927,6 +4928,19 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/v8-to-istanbul": {
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.1.0.tgz",
@@ -8662,6 +8676,12 @@
       "requires": {
         "punycode": "^2.1.0"
       }
+    },
+    "uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "dev": true
     },
     "v8-to-istanbul": {
       "version": "9.1.0",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "prettier": "^3.1.0",
     "typedoc": "^0.25.3",
     "typescript": "^5.1.6",
+    "uuid": "^9.0.1",
     "vitest": "^0.34.1"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "collaboration"
   ],
   "devDependencies": {
+    "@types/uuid": "^9.0.8",
     "@typescript-eslint/eslint-plugin": "^6.1.0",
     "@typescript-eslint/parser": "^6.1.0",
     "@vitest/coverage-c8": "^0.33.0",

--- a/src/Model.integration.test.ts
+++ b/src/Model.integration.test.ts
@@ -1,13 +1,15 @@
 import { Realtime } from 'ably/promises';
 import pino from 'pino';
 import { Subject } from 'rxjs';
+import { v4 as uuid } from 'uuid';
 import { it, describe, expect, beforeEach, afterEach, vi } from 'vitest';
 
 import Model from './Model.js';
 import { defaultSyncOptions, defaultEventBufferOptions, defaultOptimisticEventOptions } from './Options.js';
 import type { ModelOptions } from './types/model.js';
+import { fixedRetryStrategy } from './utilities/retries.js';
 import { createAblyApp } from './utilities/test/createAblyApp.js';
-import { getEventPromises } from './utilities/test/promises.js';
+import { foreachSync, getEventPromises } from './utilities/test/promises.js';
 
 interface TestContext extends ModelOptions {
   model: Model<any>;
@@ -20,262 +22,376 @@ interface TestContext extends ModelOptions {
   syncData: Record<number, any>;
 }
 
+interface TestStreamContext extends ModelOptions {
+  model: Model<any>;
+  channelName: string;
+}
+
 describe('Model integration', () => {
-  beforeEach<TestContext>(async (context) => {
-    const channelName = 'test-channel';
-    const data = await createAblyApp({
-      keys: [{}],
-      namespaces: [{ id: channelName, persisted: true }],
-      channels: [
-        {
-          name: channelName,
-          presence: [
-            { clientId: 'John', data: 'john@test.com' },
-            { clientId: 'Dave', data: 'dave@test.com' },
-          ],
+  describe('model state and optimistic events', () => {
+    beforeEach<TestContext>(async (context) => {
+      const channelName = 'test-channel';
+      const data = await createAblyApp({
+        keys: [{}],
+        namespaces: [{ id: channelName, persisted: true }],
+        channels: [
+          {
+            name: channelName,
+            presence: [
+              { clientId: 'John', data: 'john@test.com' },
+              { clientId: 'Dave', data: 'dave@test.com' },
+            ],
+          },
+        ],
+      });
+      const syncData = {
+        1: {
+          data: {
+            name: 'John',
+            email: 'john@test.io',
+          },
+          sequenceId: '1',
         },
-      ],
-    });
-    const syncData = {
-      1: {
-        data: {
-          name: 'John',
-          email: 'john@test.io',
+        2: {
+          data: {
+            city: 'London',
+            country: 'Canada',
+          },
+          sequenceId: '2',
         },
-        sequenceId: '1',
-      },
-      2: {
-        data: {
-          city: 'London',
-          country: 'Canada',
-        },
-        sequenceId: '2',
-      },
-    };
-    const ably = new Realtime({
-      key: data.keys[0].keyStr,
-      environment: 'sandbox',
-    });
-    const logger = pino({ level: 'debug' });
-    const model = new Model(
-      channelName,
-      {
-        sync: async (id: string) => syncData[id],
-        merge: (state, event) => (state ? { ...state, ...event.data } : event.data),
-      },
-      {
-        ably,
+      };
+      const ably = new Realtime({
+        key: data.keys[0].keyStr,
+        environment: 'sandbox',
+      });
+      const logger = pino({ level: 'debug' });
+      const model = new Model(
         channelName,
-        logger,
-        syncOptions: defaultSyncOptions,
-        optimisticEventOptions: defaultOptimisticEventOptions,
-        eventBufferOptions: defaultEventBufferOptions,
-      },
-    );
-
-    context.model = model;
-    context.channelName = channelName;
-    context.ably = ably;
-
-    context.eventData = {
-      name: 'update',
-      data: {
-        foo: 34,
-      },
-      mutationId: 'some-id-1',
-    };
-    context.syncData = syncData;
-  });
-
-  afterEach<TestContext>(async ({ model }) => {
-    await model.dispose();
-    vi.restoreAllMocks();
-  });
-
-  it<TestContext>('changes state on sync, pause, resume, dispose', async ({ model }) => {
-    expect(model.state).toEqual('initialized');
-
-    const sync = model.sync(1);
-    expect(model.state).toEqual('syncing');
-
-    await sync;
-    expect(model.state).toEqual('ready');
-
-    await model.pause();
-    expect(model.state).toEqual('paused');
-
-    await model.resume();
-    expect(model.state).toEqual('ready');
-
-    await model.dispose();
-    expect(model.state).toEqual('disposed');
-  });
-
-  it<TestContext>('successfully sets the data from the event in optimistic()', async ({
-    ably,
-    model,
-    channelName,
-    eventData,
-    syncData,
-  }) => {
-    await model.sync(1);
-    expect(model.data.optimistic).toEqual(syncData[1].data);
-
-    let subscription = new Subject<void>();
-    const subscriptionCalls = getEventPromises(subscription, 3);
-    const subscriptionSpy = vi.fn(() => subscription.next());
-    const finalData = { ...syncData[1].data, ...eventData.data };
-
-    model.subscribe(subscriptionSpy);
-
-    await subscriptionCalls[0];
-    expect(model.data.confirmed).toEqual(syncData[1].data);
-
-    const [confirmation] = await model.optimistic(eventData);
-
-    await subscriptionCalls[1];
-    expect(model.data.optimistic).toEqual(finalData);
-
-    const channel = ably.channels.get(channelName);
-    await channel.publish({
-      data: eventData.data,
-      name: 'update',
-      extras: {
-        headers: {
-          'x-ably-models-event-uuid': eventData.mutationId,
+        {
+          sync: async (id: string) => syncData[id],
+          merge: (state: object, event) => (state ? { ...state, ...event.data } : event.data),
         },
-      },
+        {
+          ably,
+          channelName,
+          logger,
+          syncOptions: defaultSyncOptions,
+          optimisticEventOptions: defaultOptimisticEventOptions,
+          eventBufferOptions: defaultEventBufferOptions,
+        },
+      );
+
+      context.model = model;
+      context.channelName = channelName;
+      context.ably = ably;
+
+      context.eventData = {
+        name: 'update',
+        data: {
+          foo: 34,
+        },
+        mutationId: 'some-id-1',
+      };
+      context.syncData = syncData;
     });
 
-    await subscriptionCalls[2];
-    await confirmation;
+    afterEach<TestContext>(async ({ model }) => {
+      await model.dispose();
+      vi.restoreAllMocks();
+    });
 
-    expect(subscriptionSpy).toHaveBeenCalledTimes(3);
-    expect(subscriptionSpy).toHaveBeenNthCalledWith(3, null, finalData);
-    expect(model.data.confirmed).toEqual(finalData);
+    it<TestContext>('changes state on sync, pause, resume, dispose', async ({ model }) => {
+      expect(model.state).toEqual('initialized');
+
+      const sync = model.sync(1);
+      expect(model.state).toEqual('syncing');
+
+      await sync;
+      expect(model.state).toEqual('ready');
+
+      await model.pause();
+      expect(model.state).toEqual('paused');
+
+      await model.resume();
+      expect(model.state).toEqual('ready');
+
+      await model.dispose();
+      expect(model.state).toEqual('disposed');
+    });
+
+    it<TestContext>('successfully sets the data from the event in optimistic()', async ({
+      ably,
+      model,
+      channelName,
+      eventData,
+      syncData,
+    }) => {
+      await model.sync(1);
+      expect(model.data.optimistic).toEqual(syncData[1].data);
+
+      let subscription = new Subject<void>();
+      const subscriptionCalls = getEventPromises(subscription, 3);
+      const subscriptionSpy = vi.fn(() => subscription.next());
+      const finalData = { ...syncData[1].data, ...eventData.data };
+
+      model.subscribe(subscriptionSpy);
+
+      await subscriptionCalls[0];
+      expect(model.data.confirmed).toEqual(syncData[1].data);
+
+      const [confirmation] = await model.optimistic(eventData);
+
+      await subscriptionCalls[1];
+      expect(model.data.optimistic).toEqual(finalData);
+
+      const channel = ably.channels.get(channelName);
+      await channel.publish({
+        data: eventData.data,
+        name: 'update',
+        extras: {
+          headers: {
+            'x-ably-models-event-uuid': eventData.mutationId,
+          },
+        },
+      });
+
+      await subscriptionCalls[2];
+      await confirmation;
+
+      expect(subscriptionSpy).toHaveBeenCalledTimes(3);
+      expect(subscriptionSpy).toHaveBeenNthCalledWith(3, null, finalData);
+      expect(model.data.confirmed).toEqual(finalData);
+    });
+
+    it<TestContext>('rejects the data in optimistic() and rolls back the changes if back-end rejects the data', async ({
+      ably,
+      model,
+      channelName,
+      eventData,
+      syncData,
+    }) => {
+      await model.sync(1);
+      let subscription = new Subject<void>();
+      const subscriptionCalls = getEventPromises(subscription, 2);
+      const subscriptionSpy = vi.fn(() => subscription.next());
+      const finalData = { ...syncData[1].data, ...eventData.data };
+
+      model.subscribe(subscriptionSpy);
+      await model.optimistic(eventData);
+      expect(model.data.optimistic).toEqual(finalData);
+
+      const channel = ably.channels.get(channelName);
+      await channel.publish({
+        data: eventData.data,
+        name: 'update',
+        extras: {
+          headers: {
+            'x-ably-models-event-uuid': eventData.mutationId,
+            'x-ably-models-reject': 'true',
+          },
+        },
+      });
+
+      await subscriptionCalls[0];
+      expect(model.data.confirmed).toEqual(syncData[1].data);
+
+      await subscriptionCalls[1];
+
+      expect(subscriptionSpy).toHaveBeenCalledTimes(2);
+      expect(subscriptionSpy).toHaveBeenNthCalledWith(2, null, finalData);
+      expect(model.data.confirmed).toEqual(syncData[1].data);
+    });
+
+    it<TestContext>('rejects the data and rolls back the changes if optimistic() timeouts', async ({
+      model,
+      eventData,
+      syncData,
+    }) => {
+      await model.sync(1);
+
+      let subscription = new Subject<void>();
+      const subscriptionCalls = getEventPromises(subscription, 2);
+      const subscriptionSpy = vi.fn(() => subscription.next());
+
+      model.subscribe(subscriptionSpy);
+
+      await subscriptionCalls[0];
+      expect(model.data.confirmed).toEqual(syncData[1].data);
+
+      const [confirmation] = await model.optimistic(eventData, { timeout: 10 });
+      expect(model.data.confirmed).toEqual(syncData[1].data);
+      expect(model.data.optimistic).toEqual({ ...syncData[1].data, ...eventData.data });
+
+      await subscriptionCalls[1];
+      expect(model.data.confirmed).toEqual(syncData[1].data);
+      await expect(confirmation).rejects.toThrow('timed out waiting for event confirmation');
+    });
+
+    it<TestContext>('rebases optimistic data on top of subsequent event data', async ({
+      ably,
+      model,
+      channelName,
+      eventData,
+      syncData,
+    }) => {
+      const channel = ably.channels.get(channelName);
+      const otherEvent = {
+        data: {
+          comment: "I'm blazingly fast!",
+        },
+        mutationId: 'some-id-2',
+        name: 'updateComment',
+      };
+      await model.sync(1);
+
+      let subscription = new Subject<void>();
+      const subscriptionCalls = getEventPromises(subscription, 5);
+      const subscriptionSpy = vi.fn(() => subscription.next());
+
+      model.subscribe(subscriptionSpy);
+
+      const [confirmation] = await model.optimistic(eventData);
+      expect(model.data.optimistic).toEqual({ ...syncData[1].data, ...eventData.data });
+
+      await channel.publish({
+        ...otherEvent,
+        extras: {
+          headers: {
+            'x-ably-models-event-uuid': otherEvent.mutationId,
+          },
+        },
+      });
+
+      await subscriptionCalls[2];
+      expect(model.data.confirmed).toEqual({
+        ...syncData[1].data,
+        ...otherEvent.data,
+      });
+
+      await channel.publish({
+        ...eventData,
+        extras: {
+          headers: {
+            'x-ably-models-event-uuid': eventData.mutationId,
+          },
+        },
+      });
+
+      await subscriptionCalls[5];
+      await confirmation;
+
+      expect(model.data.confirmed).toEqual({
+        ...syncData[1].data,
+        ...eventData.data,
+        ...otherEvent.data,
+      });
+    });
   });
 
-  it<TestContext>('rejects the data in optimistic() and rolls back the changes if back-end rejects the data', async ({
-    ably,
-    model,
-    channelName,
-    eventData,
-    syncData,
-  }) => {
-    await model.sync(1);
-    let subscription = new Subject<void>();
-    const subscriptionCalls = getEventPromises(subscription, 2);
-    const subscriptionSpy = vi.fn(() => subscription.next());
-    const finalData = { ...syncData[1].data, ...eventData.data };
+  describe('channel stream', () => {
+    beforeEach<TestStreamContext>(async (context) => {
+      const channelName = 'test-channel-stream-' + uuid();
+      const data = await createAblyApp({
+        keys: [{}],
+        namespaces: [{ id: channelName, persisted: true }],
+        channels: [
+          {
+            name: channelName,
+            presence: [],
+          },
+        ],
+      });
 
-    model.subscribe(subscriptionSpy);
-    await model.optimistic(eventData);
-    expect(model.data.optimistic).toEqual(finalData);
-
-    const channel = ably.channels.get(channelName);
-    await channel.publish({
-      data: eventData.data,
-      name: 'update',
-      extras: {
-        headers: {
-          'x-ably-models-event-uuid': eventData.mutationId,
-          'x-ably-models-reject': true,
+      const ably = new Realtime({
+        key: data.keys[0].keyStr,
+        environment: 'sandbox',
+      });
+      const logger = pino({ level: 'debug' });
+      const model = new Model(
+        channelName,
+        {
+          // sync: async (id: string) => ( { data: { value: id}, sequenceId: id}),
+          sync: async (id: string) => {
+            return { data: { value: id }, sequenceId: id };
+          },
+          merge: (state: object, event) => (state ? { ...state, ...event.data } : event.data),
         },
-      },
-    });
-
-    await subscriptionCalls[0];
-    expect(model.data.confirmed).toEqual(syncData[1].data);
-
-    await subscriptionCalls[1];
-
-    expect(subscriptionSpy).toHaveBeenCalledTimes(2);
-    expect(subscriptionSpy).toHaveBeenNthCalledWith(2, null, finalData);
-    expect(model.data.confirmed).toEqual(syncData[1].data);
-  });
-
-  it<TestContext>('rejects the data and rolls back the changes if optimistic() timeouts', async ({
-    model,
-    eventData,
-    syncData,
-  }) => {
-    await model.sync(1);
-
-    let subscription = new Subject<void>();
-    const subscriptionCalls = getEventPromises(subscription, 2);
-    const subscriptionSpy = vi.fn(() => subscription.next());
-
-    model.subscribe(subscriptionSpy);
-
-    await subscriptionCalls[0];
-    expect(model.data.confirmed).toEqual(syncData[1].data);
-
-    const [confirmation] = await model.optimistic(eventData, { timeout: 10 });
-    expect(model.data.confirmed).toEqual(syncData[1].data);
-    expect(model.data.optimistic).toEqual({ ...syncData[1].data, ...eventData.data });
-
-    await subscriptionCalls[1];
-    expect(model.data.confirmed).toEqual(syncData[1].data);
-    await expect(confirmation).rejects.toThrow('timed out waiting for event confirmation');
-  });
-
-  it<TestContext>('rebases optimistic data on top of subsequent event data', async ({
-    ably,
-    model,
-    channelName,
-    eventData,
-    syncData,
-  }) => {
-    const channel = ably.channels.get(channelName);
-    const otherEvent = {
-      data: {
-        comment: "I'm blazingly fast!",
-      },
-      mutationId: 'some-id-2',
-      name: 'updateComment',
-    };
-    await model.sync(1);
-
-    let subscription = new Subject<void>();
-    const subscriptionCalls = getEventPromises(subscription, 5);
-    const subscriptionSpy = vi.fn(() => subscription.next());
-
-    model.subscribe(subscriptionSpy);
-
-    const [confirmation] = await model.optimistic(eventData);
-    expect(model.data.optimistic).toEqual({ ...syncData[1].data, ...eventData.data });
-
-    await channel.publish({
-      ...otherEvent,
-      extras: {
-        headers: {
-          'x-ably-models-event-uuid': otherEvent.mutationId,
+        {
+          ably,
+          channelName,
+          logger,
+          syncOptions: { ...defaultSyncOptions, retryStrategy: fixedRetryStrategy(1, 1) },
+          optimisticEventOptions: defaultOptimisticEventOptions,
+          eventBufferOptions: defaultEventBufferOptions,
         },
-      },
+      );
+
+      context.model = model;
+      context.channelName = channelName;
+      context.ably = ably;
     });
 
-    await subscriptionCalls[2];
-    expect(model.data.confirmed).toEqual({
-      ...syncData[1].data,
-      ...otherEvent.data,
+    afterEach<TestContext>(async ({ model }) => {
+      await model.dispose();
+      vi.restoreAllMocks();
     });
 
-    await channel.publish({
-      ...eventData,
-      extras: {
-        headers: {
-          'x-ably-models-event-uuid': eventData.mutationId,
-        },
-      },
+    it<TestStreamContext>('message seeking correctly applies only the latest messages', async ({
+      model,
+      ably,
+      channelName,
+    }) => {
+      const subscriptionEventCounter = new Subject<void>();
+      const subscriptionEvents = getEventPromises(subscriptionEventCounter, 2);
+      const subscribeListener = vi.fn(() => subscriptionEventCounter.next());
+
+      const syncSequenceId = 2;
+      const messages = [
+        { id: '1', data: { value: 1 }, extras: { headers: { 'x-ably-models-event-uuid': '1' } } },
+        { id: '2', data: { value: 2 }, extras: { headers: { 'x-ably-models-event-uuid': '2' } } }, // sequenceId matches this event
+        { id: '3', data: { value: 3 }, extras: { headers: { 'x-ably-models-event-uuid': '3' } } }, // subscription event 1
+        { id: '4', data: { value: 4 }, extras: { headers: { 'x-ably-models-event-uuid': '4' } } }, // subscription event 2
+      ];
+      const channel = ably.channels.get(channelName);
+      await foreachSync(messages, ({ id, data, extras }) =>
+        channel.publish({ id, data, name: 'model-mutation', extras }),
+      );
+
+      await model.sync(syncSequenceId);
+      await model.subscribe(subscribeListener);
+
+      await subscriptionEvents[0];
+      await subscriptionEvents[1];
+
+      expect(subscribeListener).toHaveBeenCalledTimes(2);
+      expect(subscribeListener).toHaveBeenNthCalledWith(1, null, { value: 3 });
+      expect(subscribeListener).toHaveBeenNthCalledWith(2, null, { value: 4 });
     });
 
-    await subscriptionCalls[5];
-    await confirmation;
+    it<TestStreamContext>('sequence id 0 applies all history', async ({ model, ably, channelName }) => {
+      const subscriptionEventCounter = new Subject<void>();
+      const subscriptionEvents = getEventPromises(subscriptionEventCounter, 2);
+      const subscribeListener = vi.fn(() => subscriptionEventCounter.next());
 
-    expect(model.data.confirmed).toEqual({
-      ...syncData[1].data,
-      ...eventData.data,
-      ...otherEvent.data,
+      const syncSequenceId = '0';
+      const messages = [
+        { id: '7', data: { value: 7 }, extras: { headers: { 'x-ably-models-event-uuid': '7' } } },
+        { id: '3', data: { value: 3 }, extras: { headers: { 'x-ably-models-event-uuid': '3' } } },
+      ];
+      const channel = ably.channels.get(channelName);
+      await foreachSync(messages, ({ id, data, extras }) =>
+        channel.publish({ id, data, name: 'model-mutation', extras }),
+      );
+
+      await model.sync(syncSequenceId);
+      await model.subscribe(subscribeListener);
+
+      await subscriptionEvents[0];
+      await subscriptionEvents[1];
+
+      expect(subscribeListener).toHaveBeenCalledTimes(2);
+      expect(subscribeListener).toHaveBeenNthCalledWith(1, null, { value: 3 });
+      expect(subscribeListener).toHaveBeenNthCalledWith(2, null, { value: 7 });
     });
   });
 });

--- a/src/Model.test.ts
+++ b/src/Model.test.ts
@@ -1607,7 +1607,7 @@ describe('Model', () => {
     expect(lis).toHaveBeenCalledTimes(0);
   });
 
-  it<ModelTestContext>('stream message error can handle the a the StreamDiscontinuityError', async ({
+  it<ModelTestContext>('stream message error can handle the StreamDiscontinuityError', async ({
     channelName,
     ably,
     logger,

--- a/src/Model.ts
+++ b/src/Model.ts
@@ -22,6 +22,7 @@ import type {
   ConfirmedEvent,
   ExtractData,
   SyncFuncConstraint,
+  MessageId,
 } from './types/model.js';
 import {
   MODELS_EVENT_REJECT_HEADER,
@@ -480,7 +481,7 @@ export default class Model<S extends SyncFuncConstraint> extends EventEmitter<Re
       this.removeStream();
 
       const { data, sequenceId } = await this.syncFunc(...(this.lastSyncParams || ([] as unknown as Parameters<S>)));
-      if (!sequenceId) {
+      if (sequenceId === null || sequenceId === undefined) {
         const err = Error('The sync function returned an undefined sequenceId');
         // we set the state to errored here to ensure that this function is not retried by the Model.retryable()
         // this avoids a sync function that returns the wrong response structure from being retried.
@@ -519,7 +520,7 @@ export default class Model<S extends SyncFuncConstraint> extends EventEmitter<Re
     this.streamSubscriptionsMap.delete(this.stream);
   }
 
-  private async addStream(sequenceId: string) {
+  private async addStream(sequenceId: MessageId) {
     this.logger.trace({ ...this.baseLogContext, action: 'addStream()', sequenceId });
     const callback = this.onStreamMessage.bind(this);
     this.stream.subscribe(callback);

--- a/src/Model.ts
+++ b/src/Model.ts
@@ -607,7 +607,7 @@ export default class Model<S extends SyncFuncConstraint> extends EventEmitter<Re
     try {
       await this.retryable(fixedRetryStrategy(delay), fn);
     } catch (err) {
-      this.logger.warn('failed to resume after error', { ...this.baseLogContext, action: 'handleErrorResume', err });
+      this.logger.error('failed to resume after error', { ...this.baseLogContext, action: 'handleErrorResume', err });
     }
   }
 

--- a/src/stream/Middleware.ts
+++ b/src/stream/Middleware.ts
@@ -1,5 +1,6 @@
 import { Types as AblyTypes } from 'ably';
 
+import { MessageId } from '../types/model.js';
 import type { EventOrderer } from '../types/optimistic.js';
 
 abstract class MiddlewareBase {
@@ -39,7 +40,7 @@ export function lexicographicOrderer(a: string | number, b: string | number): nu
   return 1;
 }
 
-export function numericOtherwiseLexicographicOrderer(a: string, b: string): number {
+export function numericOtherwiseLexicographicOrderer(a: string | number, b: string | number): number {
   let idA: number | string, idB: number | string;
   try {
     idA = Number(a);
@@ -108,7 +109,7 @@ export class OrderedHistoryResumer extends MiddlewareBase {
   private slidingWindow: SlidingWindow;
 
   constructor(
-    private sequenceId: string,
+    private sequenceId: MessageId,
     private readonly windowSizeMs: number,
     private readonly eventOrderer: EventOrderer = numericOtherwiseLexicographicOrderer,
   ) {
@@ -125,11 +126,11 @@ export class OrderedHistoryResumer extends MiddlewareBase {
     super.next(message!);
   }
 
-  private reverseOrderer(a: string, b: string) {
+  private reverseOrderer(a: MessageId, b: MessageId) {
     return this.eventOrderer(a, b) * -1;
   }
 
-  private messageBeforeInclusive(a: string, b: string) {
+  private messageBeforeInclusive(a: MessageId, b: MessageId) {
     return this.eventOrderer(a, b) <= 0;
   }
 

--- a/src/stream/Stream.test.ts
+++ b/src/stream/Stream.test.ts
@@ -270,7 +270,7 @@ describe('Stream', () => {
     });
   });
 
-  it<StreamTestContext>('successfully syncs if sequenceId is 0 with multiple pages of history', async ({
+  it<StreamTestContext>('successfully syncs if sequenceId is "0" with multiple pages of history', async ({
     ably,
     logger,
     channelName,
@@ -310,6 +310,63 @@ describe('Stream', () => {
     });
     stream.subscribe(subscribeListener);
     let replayPromise = stream.replay('0');
+
+    await statePromise(stream, 'seeking');
+    await expect(replayPromise).resolves.toBeUndefined();
+
+    expect(channel.subscribe).toHaveBeenCalledOnce();
+    expect(channel.history).toHaveBeenCalledTimes(2);
+    expect(channel.history).toHaveBeenNthCalledWith(1, {
+      untilAttach: true,
+      limit: defaultSyncOptions.historyPageSize,
+    });
+    expect(channel.history).toHaveBeenNthCalledWith(2, {
+      untilAttach: true,
+      limit: defaultSyncOptions.historyPageSize,
+    });
+    expect(subscribeListener).toHaveBeenCalledTimes(6);
+  });
+
+  it<StreamTestContext>('successfully syncs if sequenceId is 0 with multiple pages of history', async ({
+    ably,
+    logger,
+    channelName,
+  }) => {
+    const subscribeListener = vi.fn();
+    const channel = ably.channels.get(channelName);
+    ably.channels.release = vi.fn();
+    channel.subscribe = vi.fn<any, any>(
+      async (): Promise<Types.ChannelStateChange | null> => ({
+        current: 'attached',
+        previous: 'attaching',
+        resumed: false,
+        hasBacklog: false,
+      }),
+    );
+    let i = 0;
+    channel.history = vi.fn<any, any>(async (): Promise<Partial<Types.PaginatedResult<Types.Message>>> => {
+      i++;
+      if (i === 1) {
+        return {
+          items: [createMessage(7), createMessage(6), createMessage(5)],
+          hasNext: () => true,
+        };
+      }
+      return {
+        items: [createMessage(4), createMessage(3), createMessage(2)],
+        hasNext: () => false,
+      };
+    });
+
+    const stream = new Stream({
+      ably,
+      logger,
+      channelName: 'foobar',
+      syncOptions: defaultSyncOptions,
+      eventBufferOptions: defaultEventBufferOptions,
+    });
+    stream.subscribe(subscribeListener);
+    let replayPromise = stream.replay(0);
 
     await statePromise(stream, 'seeking');
     await expect(replayPromise).resolves.toBeUndefined();

--- a/src/stream/Stream.test.ts
+++ b/src/stream/Stream.test.ts
@@ -270,7 +270,7 @@ describe('Stream', () => {
     });
   });
 
-  it<StreamTestContext>('successfully to syncs if sequenceId is 0 with multiple pages of history', async ({
+  it<StreamTestContext>('successfully syncs if sequenceId is 0 with multiple pages of history', async ({
     ably,
     logger,
     channelName,
@@ -327,7 +327,7 @@ describe('Stream', () => {
     expect(subscribeListener).toHaveBeenCalledTimes(6);
   });
 
-  it<StreamTestContext>('successfully to syncs if sequenceId is 0 with 2 pages of history, second one empty', async ({
+  it<StreamTestContext>('successfully syncs if sequenceId is 0 with 2 pages of history, second one empty', async ({
     ably,
     logger,
     channelName,

--- a/src/stream/Stream.ts
+++ b/src/stream/Stream.ts
@@ -197,6 +197,14 @@ export default class Stream extends EventEmitter<Record<StreamState, StreamState
       n++;
     } while (page && page.items && page.items.length > 0 && page.hasNext() && !done);
 
+    if (sequenceId === '0' && this.middleware.state !== 'success') {
+      // The sequenceId is 0 there will be no message in the history to match it.
+      // The middleware is not in success which means there is some history so we apply it
+      // The situation occurs when history has been added in the time between the sync function resolving the stream
+      // getting to this point
+      this.middleware.applyHistory();
+    }
+
     // If the middleware is not in the success state it means there were some history messages and we never reached the target sequenceId.
     // This means the target sequenceId was too old and a re-sync from a newer state snapshot is required.
     if (this.middleware.state !== 'success') {

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -130,6 +130,10 @@ export type OptimisticEvent = Event & {
 };
 
 /**
+ * A message ID used to identify an event. Used for message seeking.
+ */
+export type MessageId = string | number;
+/**
  * An event received from the backend over Ably that represents a confirmed change on the underlying state in the database.
  */
 export type ConfirmedEvent = Event & {
@@ -174,7 +178,7 @@ export type SyncFunc<F extends SyncFuncConstraint> = F;
  * @returns {Promise<{data: T, sequenceId: string}>} A promise containing the data from the backend and a sequenceId.
  * @interface
  */
-export type SyncReturnType<T> = Promise<{ data: T; sequenceId: string }>;
+export type SyncReturnType<T> = Promise<{ data: T; sequenceId: MessageId }>;
 
 /**
  * Type constraint for a sync function.

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -145,7 +145,7 @@ export type ConfirmedEvent = Event & {
    * If true, indicates that the backend is (asynchronously) explicitly rejecting this optimistic change.
    * This is useful if the server cannot reject the change synchronously with the mutation request
    * (such as if the rejection occurred after the backend sent a response).
-   * This field is set to `true` iff. there is an `x-ably-models-reject: true` header in the message extras.
+   * This field is set to `true` if. there is an `x-ably-models-reject: true` header in the message extras.
    * @see https://ably.com/docs/api/realtime-sdk/messages?lang=nodejs#extras
    */
   rejected: boolean;

--- a/src/types/optimistic.ts
+++ b/src/types/optimistic.ts
@@ -13,11 +13,11 @@ export type EventComparator = (optimistic: Event, confirmed: Event) => boolean;
  * EventOrderer is used to determine the order of elements in the event buffer. It expects
  * to return a negative value of the first argument is less than the second argument, zero
  * if they are equal, and a positive value otherwise.
- * @param {string} a - The first event ID.
- * @param {string} b - The second event ID.
+ * @param {string | number} a - The first event ID.
+ * @param {string | number} b - The second event ID.
  * @param {number} - A negative value if a < b, zero if a == b, a positive value otherwise.
  */
-export type EventOrderer = (a: string, b: string) => number;
+export type EventOrderer = (a: string | number, b: string | number) => number;
 
 /**
  * OptimisticEventOptions can be used to configure options on individual optimistic events.

--- a/src/utilities/test/promises.ts
+++ b/src/utilities/test/promises.ts
@@ -9,3 +9,11 @@ export const getEventPromises = <T>(subject: Subject<T>, n: number) => {
   }
   return promises;
 };
+
+export async function foreachSync(data: any[], callback: Function): Promise<void> {
+  for (let i = 0; i < data.length; i++) {
+    await callback(data[i]);
+  }
+
+  return;
+}


### PR DESCRIPTION
This PR adds tests and validation handling for the sequenceId return from the configured sync function.

Conditions:
- [x] 1. SequenceId is `undefined`
- [x] 2. SequenceId is `'0'` and there is history in the channel. In which case history should be applied.


Previous PR: https://github.com/ably-labs/models/pull/162, I had to change the branch name because I used the wrong jira reference. Old comments are here are on the original PR

# Comments

In condition 1 where the sequenceId is `undefined`, the solution in this PR is throw an error and set the model state to `errored`. Additionally the `retryable()` logic has been updated to not run the callback function if the model is in the `errored` state. Additionally if we catch an error while in the errored state then we re throw it, propagating it up the call stack. This is how the new `sequenceId is undefined error` will be surfaced to the user. 

# Other changes

Error handling has been improved so that all errors produced by the SDK during event handling function or in places where a user would not be able to catch them have been silenced and are exposed through the 'errored' event.

The docs around the Models's sync and subscribe methods have been updated so that the user knows to catch any errors thrown by these functions.

An integration test has been added that covers all message history being applied to model with sequenceId 0 and, seek and applying history with a sequenceId of 1 or more.

The `uuid` package has been added as a dev dependancy. 

The current integration test located in `./src/Model.integration.test.ts` has been wrapped in its own describe as the test set up new test is different. This test are now isolated. I have also added uuids to the channel name so that each test run uses a different channel.