### PR TITLE
DTP-723: Model subscribe method fails if the Model is initialized

### DIFF
--- a/src/Model.integration.test.ts
+++ b/src/Model.integration.test.ts
@@ -361,7 +361,7 @@ describe('Model integration', () => {
       );
 
       await model.sync(syncSequenceId);
-      await model.subscribe(subscribeListener);
+      model.subscribe(subscribeListener);
 
       await subscriptionEvents[0];
       await subscriptionEvents[1];
@@ -387,7 +387,7 @@ describe('Model integration', () => {
       );
 
       await model.sync(syncSequenceId);
-      await model.subscribe(subscribeListener);
+      model.subscribe(subscribeListener);
 
       await subscriptionEvents[0];
       await subscriptionEvents[1];


### PR DESCRIPTION
The subscribe method on the model now throws an error is sub scribe is called on a model that has not been initialised. The `subscribe` method is no longer an asynchronous function.